### PR TITLE
fix(deps): ignore vitest v3.x to prevent engine compatibility issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,13 @@ updates:
       # Keep commander at v13.x to maintain Node.js 18 compatibility
       - dependency-name: "commander"
         versions: [">=14.0.0"]
+      # Keep vitest at v2.x to avoid engine compatibility issues
+      - dependency-name: "vitest"
+        versions: [">=3.0.0"]
+      - dependency-name: "@vitest/coverage-v8"
+        versions: [">=3.0.0"]
+      - dependency-name: "@vitest/ui"
+        versions: [">=3.0.0"]
 
   # Individual packages only if they have unique dependencies
   - package-ecosystem: "npm" 


### PR DESCRIPTION
## Problem
The Dependabot PR for vitest 3.x upgrade is failing with `ERR_PNPM_UNSUPPORTED_ENGINE` errors.

## Solution
Add ignore rules for vitest v3.x dependencies to keep us on stable v2.x:
- `vitest >= 3.0.0`
- `@vitest/coverage-v8 >= 3.0.0` 
- `@vitest/ui >= 3.0.0`

## Benefits
- Prevents engine compatibility issues with Node.js 18.19.1 setup
- Keeps us on stable vitest 2.x until we can properly test v3 upgrade
- Stops failing Dependabot PRs that can't be auto-merged

## Related Issues
- Fixes the failing 'bump the testing group with 3 updates' Dependabot PR #14