### PR TITLE
fix(deps): sync aws-cdk-lib to 2.218.0 across all projects

### DIFF
--- a/aws-cdk-examples/eks/package.json
+++ b/aws-cdk-examples/eks/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@aws-cdk/lambda-layer-kubectl-v32": "2.1.0",
     "@aws-cdk/lambda-layer-kubectl-v33": "2.0.0",
-    "aws-cdk-lib": "2.217.0",
+    "aws-cdk-lib": "2.218.0",
     "constructs": "10.4.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-cdk/lambda-layer-kubectl-v33": "2.0.0",
-    "aws-cdk-lib": "2.217.0",
+    "aws-cdk-lib": "2.218.0",
     "commander": "13.1.0",
     "constructs": "10.4.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
     dependencies:
       '@aws-cdk/lambda-layer-kubectl-v33':
         specifier: 2.0.0
-        version: 2.0.0(aws-cdk-lib@2.217.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.0.0(aws-cdk-lib@2.218.0(constructs@10.4.2))(constructs@10.4.2)
       aws-cdk-lib:
-        specifier: 2.217.0
-        version: 2.217.0(constructs@10.4.2)
+        specifier: 2.218.0
+        version: 2.218.0(constructs@10.4.2)
       commander:
         specifier: 13.1.0
         version: 13.1.0
@@ -50,13 +50,13 @@ importers:
     dependencies:
       '@aws-cdk/lambda-layer-kubectl-v32':
         specifier: 2.1.0
-        version: 2.1.0(aws-cdk-lib@2.217.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.1.0(aws-cdk-lib@2.218.0(constructs@10.4.2))(constructs@10.4.2)
       '@aws-cdk/lambda-layer-kubectl-v33':
         specifier: 2.0.0
-        version: 2.0.0(aws-cdk-lib@2.217.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.0.0(aws-cdk-lib@2.218.0(constructs@10.4.2))(constructs@10.4.2)
       aws-cdk-lib:
-        specifier: 2.217.0
-        version: 2.217.0(constructs@10.4.2)
+        specifier: 2.218.0
+        version: 2.218.0(constructs@10.4.2)
       constructs:
         specifier: 10.4.2
         version: 10.4.2
@@ -1014,8 +1014,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  aws-cdk-lib@2.217.0:
-    resolution: {integrity: sha512-vPxTMF3IDW0Bf5m07yxebWjzZhd5/DcEPKusu4F9krnTORhx2UMqcTyvAmb7SLbi2+FrKYhP5w4nPBNxf8LhHA==}
+  aws-cdk-lib@2.218.0:
+    resolution: {integrity: sha512-gYt4xlakJ9o/eY6jjzeJDRuy+gjnmHSUG+8t2Pb9ulMApOKEEAQrCJ9vucYLLosVghzTXIAiDiC7k1Dgm63HBg==}
     engines: {node: '>= 18.0.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -1927,14 +1927,14 @@ snapshots:
 
   '@aws-cdk/cloud-assembly-schema@48.11.0': {}
 
-  '@aws-cdk/lambda-layer-kubectl-v32@2.1.0(aws-cdk-lib@2.217.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/lambda-layer-kubectl-v32@2.1.0(aws-cdk-lib@2.218.0(constructs@10.4.2))(constructs@10.4.2)':
     dependencies:
-      aws-cdk-lib: 2.217.0(constructs@10.4.2)
+      aws-cdk-lib: 2.218.0(constructs@10.4.2)
       constructs: 10.4.2
 
-  '@aws-cdk/lambda-layer-kubectl-v33@2.0.0(aws-cdk-lib@2.217.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/lambda-layer-kubectl-v33@2.0.0(aws-cdk-lib@2.218.0(constructs@10.4.2))(constructs@10.4.2)':
     dependencies:
-      aws-cdk-lib: 2.217.0(constructs@10.4.2)
+      aws-cdk-lib: 2.218.0(constructs@10.4.2)
       constructs: 10.4.2
 
   '@aws-crypto/crc32@5.2.0':
@@ -3115,7 +3115,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  aws-cdk-lib@2.217.0(constructs@10.4.2):
+  aws-cdk-lib@2.218.0(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.242
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0


### PR DESCRIPTION
## 🔧 Fix: Dependabot AWS CDK Version Sync

### **Problem**
- Dependabot PR #26 failed with `NoChangeError` when trying to update `aws-cdk-lib`
- Root workspace was at version `2.217.0` but Dependabot expected `2.208.0`
- Version mismatch between workspace packages caused update conflicts

### **Solution**
- ✅ Updated root workspace: `aws-cdk-lib` `2.217.0` → `2.218.0`
- ✅ Updated EKS project: `aws-cdk-lib` `2.217.0` → `2.218.0`
- ✅ Synchronized versions across monorepo
- ✅ Updated lockfile to reflect changes

### **Changes**
- `package.json`: aws-cdk-lib updated to 2.218.0
- `aws-cdk-examples/eks/package.json`: aws-cdk-lib updated to 2.218.0
- `pnpm-lock.yaml`: Updated with new dependency versions

### **Impact**
- 🚫 Prevents future Dependabot `NoChangeError` failures
- ✅ Ensures consistent CDK versions across all projects
- 🔄 Enables proper Dependabot auto-updates going forward

### **Testing**
- [x] Version consistency verified across workspace
- [x] Dependencies resolve correctly
- [x] No breaking changes in CDK 2.218.0

Closes #26 (resolves Dependabot failure)

/cc @dependabot